### PR TITLE
chore: Doc Touchups Mostly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-hoist"
 description = "Dead simple, memoized cargo subcommand to hoist cargo-built binaries into the current working directory."
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 license = "MIT"
 authors = ["refcell"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [Docs-rs]: https://docs.rs/cargo-hoist/
 [Docs]: https://img.shields.io/docsrs/cargo-hoist.svg?color=319e8c&label=docs.rs
 
-**Dead simple cargo subcommand to hoist cargo-built binaries into the current working directory.** hoist is https://github.com/refcell/cargo-hoist/labels/beta
+**Dead simple cargo subcommand to hoist cargo-built binaries into the current working directory.** cargo-hoist is https://github.com/refcell/cargo-hoist/labels/beta
 
 ![](./etc/banner.png)
 
@@ -56,14 +56,16 @@ cargo install cargo-hoist
 
 Contributions of all forms are welcome and encouraged!
 
-## Troubleshooting & Bug Reports
+Please check [existing issues][issues] for similar feature requests or bug reports.
 
-Please check existing issues for similar bugs or
-[open an issue](https://github.com/refcell/cargo-hoist/issues/new)
-if no relevant issue already exists.
+Otherwise, feel free to [open an issue][oissue] if no relevant issue already exists.
+
+[issues]: https://github.com/refcell/cargo-hoist/issues
+[oissue]: https://github.com/refcell/cargo-hoist/issues/new
+
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE.md).
-Free and open-source, forever.
-*All our rust are belong to you.*
+This project is licensed under the [MIT License][mit-license].
+
+Free and open-source, forever. *All our rust are belong to you.*

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub struct Args {
     #[arg(long, short, action = ArgAction::Count, default_value = "0")]
     verbosity: u8,
 
-    /// The subcommand to run
+    /// The cargo-hoist subcommand
     #[clap(subcommand)]
     pub command: Option<Command>,
 }


### PR DESCRIPTION
**Description**

Mostly touches up `cargo-hoist` docs. Also performs a path version bump to test the workflow overlords.
